### PR TITLE
Debugging katy

### DIFF
--- a/CIAlign/CIAlign.py
+++ b/CIAlign/CIAlign.py
@@ -23,7 +23,8 @@ except ImportError:
 def main():
 
     parser = configargparse.ArgumentParser(
-                description='''Clean and interpret a multiple sequence alignment''',
+                description='Clean and interpret a multiple sequence \
+                             alignment',
                 add_help=False)
     required = parser.add_argument_group('Required Arguments')
     optional = parser.add_argument_group('Optional Arguments')
@@ -38,7 +39,8 @@ def main():
                  is_config_file=True)
     optional.add("--outfile_stem", dest='outfile_stem', type=str,
                  default="CIAlign",
-                 help="Prefix for output files, including the path to the output directory. Default: %(default)s")
+                 help="Prefix for output files, including the path to the \
+                     output directory. Default: %(default)s")
 
     # parameter to run all functions without having to type them in
     optional.add("--all", dest="all_options",
@@ -47,85 +49,116 @@ def main():
 
     # Runtime
     optional.add("--silent", dest='silent',
-                 help="Do not print progress to the screen. Default: %(default)s",
+                 help="Do not print progress to the screen. \
+                       Default: %(default)s",
                  action='store_true')
 
     # Crop Ends
     optional.add("--crop_ends", dest="crop_ends",
                  action="store_true",
-                 help="Crop the ends of sequences if they are poorly aligned. Default: %(default)s")
+                 help="Crop the ends of sequences if they are poorly aligned. \
+                 Default: %(default)s")
     optional.add("--crop_ends_mingap_perc", dest='crop_ends_mingap_perc',
                  type=float, default=0.05,
-                 help="Minimum proportion of the sequence length (excluding gaps) that is the threshold for change in gap numbers. Default: %(default)s")
+                 help="Minimum proportion of the sequence length (excluding \
+                     gaps) that is the threshold for change in gap numbers. \
+                     Default: %(default)s")
     optional.add("--crop_ends_redefine_perc", dest='crop_ends_redefine_perc',
                  type=float, default=0.1,
-                 help="Proportion of the sequence length (excluding gaps) that is being checked for change in gap numbers to redefine start/end. Default: %(default)s")
+                 help="Proportion of the sequence length (excluding gaps) \
+                       that is being checked for change in gap numbers to \
+                       redefine start/end. Default: %(default)s")
 
     # Remove divergent sequences
     optional.add("--remove_divergent", dest="remove_divergent",
                  action="store_true",
-                 help="Remove sequences with <= N proportion of positions at which the most common base / amino acid in the alignment is present. Default: %(default)s")
+                 help="Remove sequences with <= N proportion of positions at \
+                       which the most common base / amino acid in the \
+                       alignment is present. Default: %(default)s")
     optional.add("--remove_divergent_minperc", dest="remove_divergent_minperc",
                  type=float, default=0.75,
-                 help="Minimum proportion of positions which should be identical to the most common base / amino acid in order to be preserved. Default: %(default)s")
+                 help="Minimum proportion of positions which should be \
+                       identical to the most common base / amino acid in \
+                       order to be preserved. Default: %(default)s")
 
     # # Remove Insertions
     optional.add("--remove_insertions", dest="remove_insertions",
                  action="store_true",
-                 help="Remove insertions found in <= 50 percent of sequences from the alignment. Default: %(default)s")
+                 help="Remove insertions found in <= 50 percent of sequences \
+                       from the alignment. Default: %(default)s")
     optional.add("--insertion_min_size", dest="insertion_min_size",
                  type=int, default=3,
-                 help="Only remove insertions >= this number of residues. Default: %(default)s")
+                 help="Only remove insertions >= this number of residues. \
+                       Default: %(default)s")
     optional.add("--insertion_max_size", dest="insertion_max_size",
                  type=int, default=300,
-                 help="Only remove insertions <= this number of residues. Default: %(default)s")
+                 help="Only remove insertions <= this number of residues. \
+                       Default: %(default)s")
     optional.add("--insertion_min_flank", dest="insertion_min_flank",
                  type=int, default=5,
-                 help="Minimum number of bases on either side of an insertion to classify it as an insertion. Default: %(default)s")
+                 help="Minimum number of bases on either side of an insertion \
+                       to classify it as an insertion. Default: %(default)s")
 
     # Remove Short
     optional.add("--remove_short", dest="remove_short",
-                 help="Remove sequences <= N bases / amino acids from the alignment. Default: %(default)s",
+                 help="Remove sequences <= N bases / amino acids from the \
+                       alignment. Default: %(default)s",
                  action="store_true")
     optional.add("--remove_min_length", dest="remove_min_length",
                  type=int, default=50,
-                 help="Sequences are removed if they are shorter than this minimum length, excluding gaps. Default: %(default)s")
+                 help="Sequences are removed if they are shorter than this \
+                       minimum length, excluding gaps. Default: %(default)s")
 
     # keep gap only
     optional.add("--keep_gaponly", dest="remove_gaponly",
                  action="store_false",
-                 help="Keep gap only columns in the alignment. Default: %(default)s")
+                 help="Keep gap only columns in the alignment. Default: \
+                       %(default)s")
 
     # Consensus
     optional.add("--make_consensus", dest="make_consensus",
                  action="store_true",
-                 help="Make a consensus sequence based on the cleaned alignment. Default: %(default)s")
+                 help="Make a consensus sequence based on the cleaned \
+                       alignment. Default: %(default)s")
     optional.add("--consensus_type", dest="consensus_type", type=str,
                  default="majority",
-                 help="Type of consensus sequence to make - can be majority, to use the most common character at each position in the consensus, even if this is a gap, or majority_nongap, to use the most common non-gap character at each position. Default: %(default)s")
+                 help="Type of consensus sequence to make - can be majority, \
+                       to use the most common character at each position in \
+                       the consensus, even if this is a gap, or \
+                       majority_nongap, to use the most common non-gap \
+                       character at each position. Default: %(default)s")
     optional.add("--consensus_keep_gaps", dest="consensus_keep_gaps",
                  action="store_true",
-                 help="If there are gaps in the consensus (if majority_nongap is used as consensus_type), should these be included in the consensus (True) or should this position in the consensus be deleted (False). Default: %(default)s")
+                 help="If there are gaps in the consensus (if majority_nongap \
+                       is used as consensus_type), should these be included \
+                       in the consensus (True) or should this position in \
+                      the consensus be deleted (False). Default: %(default)s")
     optional.add("--consensus_name", dest="consensus_name",
                  type=str, default="consensus",
-                 help="Name to use for the consensus sequence in the output fasta file. Default: %(default)s")
+                 help="Name to use for the consensus sequence in the output \
+                       fasta file. Default: %(default)s")
 
     # Mini Alignments
     optional.add("--plot_input", dest="plot_input",
                  action="store_true",
-                 help="Plot a mini alignment - an image representing the input alignment. Default: %(default)s")
+                 help="Plot a mini alignment - an image representing the \
+                       input alignment. Default: %(default)s")
     optional.add("--plot_output", dest="plot_output",
                  action="store_true",
-                 help="Plot a mini alignment, an image representing the output alignment. Default: %(default)s")
+                 help="Plot a mini alignment, an image representing the \
+                       output alignment. Default: %(default)s")
     optional.add("--plot_markup", dest="plot_markup",
                  action="store_true",
-                 help="Draws the input alignment but with the columns and rows which have been removed by each function marked up in corresponding colours. Default: %(default)s")
+                 help="Draws the input alignment but with the columns and \
+                       rows which have been removed by each function marked \
+                       up in corresponding colours. Default: %(default)s")
     optional.add("--plot_dpi", dest="plot_dpi",
                  type=int, default=300,
                  help="DPI for mini alignments. Default: %(default)s")
     optional.add("--plot_format", dest="plot_format",
                  type=str, default='png',
-                 help="Image format for mini alignments - can be png, svg, tiff or jpg. Default: %(default)s")
+                 help="Image format for mini alignments - can be png, svg, \
+                       tiff or jpg. Default: %(default)s")
     optional.add("--plot_width", dest="plot_width",
                  type=int, default=5,
                  help="Mini alignment width in inches. Default: %(default)s")
@@ -139,7 +172,8 @@ def main():
                  help="Draw a sequence logo. Default: %(default)s")
     optional.add("--sequence_logo_type", dest="sequence_logo_type",
                  type=str, default='bar',
-                 help="Type of sequence logo - bar/text/both. Default: %(default)s")
+                 help="Type of sequence logo - bar/text/both. \
+                       Default: %(default)s")
     optional.add("--sequence_logo_dpi", dest="sequence_logo_dpi",
                  type=int, default=300,
                  help="DPI for sequence logo image. Default: %(default)s")
@@ -148,74 +182,103 @@ def main():
                  help="Font for text sequence logo. Default: %(default)s")
     optional.add("--sequence_logo_nt_per_row", dest='sequence_logo_nt_per_row',
                  type=int, default=50,
-                 help="Number of bases / amino acids to show per row in the sequence logo, where the logo is too large to show on a single line. Default: %(default)s")
+                 help="Number of bases / amino acids to show per row in the \
+                       sequence logo, where the logo is too large to show on \
+                       a single line. Default: %(default)s")
     optional.add("--sequence_logo_filetype", dest='sequence_logo_filetype',
                  type=str, default='png',
-                 help="Image file type to use for the sequence logo - can be png, svg, tiff or jpg. Default: %(default)s")
+                 help="Image file type to use for the sequence logo - can be \
+                       png, svg, tiff or jpg. Default: %(default)s")
     optional.add("--list_fonts_only", dest='list_fonts_only',
                  action="store_true",
-                 help="Make a swatch showing available fonts. Default: %(default)s")
+                 help="Make a swatch showing available fonts. \
+                       Default: %(default)s")
 
     # Coverage
     optional.add("--plot_coverage_input", dest="plot_coverage_input",
                  action="store_true",
-                 help="Plot the coverage of the input MSA. Default: %(default)s")
+                 help="Plot the coverage of the input MSA. Default: \
+                       %(default)s")
     optional.add("--plot_coverage_output", dest="plot_coverage_output",
                  action="store_true",
-                 help="Plot the coverage of the output MSA. Default: %(default)s")
+                 help="Plot the coverage of the output MSA. Default: \
+                       %(default)s")
     optional.add("--plot_coverage_dpi", dest="plot_coverage_dpi",
                  type=int, default=300,
                  help="DPI for coverage plot. Default: %(default)s")
     optional.add("--plot_coverage_height", dest="plot_coverage_height",
                  type=int, default=3,
-                 help="Height for coverage plot (inches). Default: %(default)s")
+                 help="Height for coverage plot (inches). Default: \
+                       %(default)s")
     optional.add("--plot_coverage_width", dest="plot_coverage_width",
                  type=int, default=5,
-                 help="Width for coverage plot (inches). Default: %(default)s")
+                 help="Width for coverage plot (inches). Default: \
+                       %(default)s")
     optional.add("--plot_coverage_colour", dest="plot_coverage_colour",
                  type=str, default='#007bf5',
-                 help="Colour for coverage plot (hex code or name). Default: %(default)s")
+                 help="Colour for coverage plot (hex code or name). \
+                       Default: %(default)s")
     optional.add("--plot_coverage_filetype", dest="plot_coverage_filetype",
                  type=str, default='png',
-                 help="File type for coverage plot (png, svg, tiff, jpg). Default: %(default)s")
+                 help="File type for coverage plot (png, svg, tiff, jpg). \
+                       Default: %(default)s")
 
     # Similarity Matrix
     optional.add("--make_similarity_matrix_input", dest="make_simmatrix_input",
                  action="store_true",
-                 help="Make a similarity matrix for the input alignment. Default: %(default)s")
-    optional.add("--make_similarity_matrix_output", dest="make_simmatrix_output",
+                 help="Make a similarity matrix for the input alignment. \
+                       Default: %(default)s")
+    optional.add("--make_similarity_matrix_output",
+                 dest="make_simmatrix_output",
                  action="store_true",
-                 help="Make a similarity matrix for the output alignment. Default: %(default)s")
+                 help="Make a similarity matrix for the output alignment. \
+                       Default: %(default)s")
     optional.add("--make_simmatrix_dp", dest="make_simmatrix_dp",
                  type=int, default=4,
-                 help="Number of decimal places to display in the similarity matrix output file. Default: %(default)s")
+                 help="Number of decimal places to display in the similarity \
+                       matrix output file. Default: %(default)s")
     optional.add("--make_simmatrix_minoverlap",
                  dest="make_simmatrix_minoverlap",
                  type=int, default=1,
-                 help="Minimum overlap between two sequences to have non-zero similarity in the similarity matrix. Default: %(default)s")
+                 help="Minimum overlap between two sequences to have non-zero \
+                       similarity in the similarity matrix. \
+                       Default: %(default)s")
     optional.add("--make_simmatrix_keepgaps", dest="make_simmatrix_keepgaps",
                  type=bool, default=False,
-                 help="Include positions with gaps in either or both sequences in the similarity matrix calculation. Default: %(default)s")
+                 help="Include positions with gaps in either or both \
+                       sequences in the similarity matrix calculation. \
+                       Default: %(default)s")
 
     # Unalign function
-    optional.add("--unalign_input", dest="unalign_input", action="store_true", default=False,
-                 help="Generate a copy of the input alignment with no gaps. Default: %(default)s")
-    optional.add("--unalign_output", dest="unalign_output", action="store_true", default=False,
-                 help="Generate a copy of the cleaned alignment with no gaps. Default: %(default)s")
+    optional.add("--unalign_input", dest="unalign_input",
+                 action="store_true", default=False,
+                 help="Generate a copy of the input alignment with no gaps. \
+                       Default: %(default)s")
+    optional.add("--unalign_output", dest="unalign_output",
+                 action="store_true", default=False,
+                 help="Generate a copy of the cleaned alignment with no \
+                     gaps. Default: %(default)s")
 
     # Replace Us by Ts function
-    optional.add("--replace_input", dest="replace_input", action="store_true", default=False,
-                 help="Replaces all Us by Ts in input alignment. Default: %(default)s")
-    optional.add("--replace_output", dest="replace_output", action="store_true", default=False,
-                 help="Replaces all Us by Ts in output alignment. Default: %(default)s")
+    optional.add("--replace_input", dest="replace_input", action="store_true",
+                 default=False,
+                 help="Replaces all Us by Ts in input alignment. \
+                     Default: %(default)s")
+    optional.add("--replace_output", dest="replace_output",
+                 action="store_true", default=False,
+                 help="Replaces all Us by Ts in output alignment. \
+                     Default: %(default)s")
 
     # Help function
-    optional.add('-h', '--help', action='help', default=configargparse.SUPPRESS,
+    optional.add('-h', '--help', action='help',
+                 default=configargparse.SUPPRESS,
                  help='Show all available parameters with an explanation.')
 
     # Version function
-    optional.add('-v', '--version', action='version', version = __version__, default=configargparse.SUPPRESS,
-                     help='Show the current version.')
+    optional.add('-v', '--version', action='version',
+                 version=__version__,
+                 default=configargparse.SUPPRESS,
+                 help='Show the current version.')
 
     args = parser.parse_args()
 
@@ -227,7 +290,8 @@ def main():
     handler.setLevel(logging.INFO)
 
     # create a logging format
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     handler.setFormatter(formatter)
     rmfile = "%s_removed.txt" % args.outfile_stem
     outfile = "%s_cleaned.fasta" % (args.outfile_stem)
@@ -262,9 +326,9 @@ def main():
         print("Error! Your input alignmnent has duplicate names!")
         exit()
 
-    cmt_file = args.outfile_stem + "_cmt" # output file to store memory and time
-    seqnumber = len(arr)
-    msalength = len(arr[0])
+    # output file to store memory and time
+    cmt_file = args.outfile_stem + "_cmt"
+
     cleaningArgs = [args.remove_insertions,
                     args.crop_ends,
                     args.remove_divergent]
@@ -274,6 +338,9 @@ def main():
         # when less than three sequences, stop
         print("You need at least three sequences in your MSA to run \
                remove_insertions, crop_ends or remove_divergent")
+        exit()
+    elif len(arr) < 2:
+        print("You need at least two sequences in your MSA")
         exit()
 
     # store a copy of the original array
@@ -304,15 +371,14 @@ def main():
     reset_rmfile.close()
     utilityFunctions.checkArrLength(arr, log)
 
-
     if args.remove_divergent or args.all_options:
         log.info("Removing divergent sequences")
         if not args.silent:
             print("Removing divergent sequences")
+        minperc = args.remove_divergent_minperc
         arr, r = parsingFunctions.removeDivergent(arr, nams,
-                                                     rmfile, log,
-                                                     args.remove_divergent_minperc)
-
+                                                  rmfile, log,
+                                                  minperc)
 
         markupdict['remove_divergent'] = r
         removed_seqs = removed_seqs | r
@@ -323,11 +389,11 @@ def main():
         log.info("Removing gap only columns")
         if not args.silent:
             print("Removing gap only columns")
-        arr, r, relativePositions = parsingFunctions.removeGapOnly(arr,
-                                                                   relativePositions,
-                                                                   rmfile,
-                                                                   log)
-
+        A = parsingFunctions.removeGapOnly(arr,
+                                           relativePositions,
+                                           rmfile,
+                                           log)
+        arr, r, relativePositions = A
 
         if 'remove_gaponly' in markupdict:
             markupdict['remove_gaponly'].update(r)
@@ -340,29 +406,30 @@ def main():
         log.info("Removing insertions")
         if not args.silent:
             print("Removing insertions")
-        arr, r, relativePositions = parsingFunctions.removeInsertions(arr,
-                                                                      relativePositions,
-                                                                      rmfile,
-                                                                      log,
-                                                                      args.insertion_min_size,
-                                                                      args.insertion_max_size,
-                                                                      args.insertion_min_flank)
 
+        A = parsingFunctions.removeInsertions(arr,
+                                              relativePositions,
+                                              rmfile,
+                                              log,
+                                              args.insertion_min_size,
+                                              args.insertion_max_size,
+                                              args.insertion_min_flank)
 
+        arr, r, relativePositions = A
         markupdict['remove_insertions'] = r
         removed_cols = removed_cols | r
         utilityFunctions.checkArrLength(arr, log)
-
 
     if (args.remove_insertions and args.remove_gaponly) or args.all_options:
         log.info("Removing gap only columns")
         if not args.silent:
             print("Removing gap only columns")
 
-        arr, r, relativePositions = parsingFunctions.removeGapOnly(arr,
-                                                                   relativePositions,
-                                                                   rmfile,
-                                                                   log)
+        A = parsingFunctions.removeGapOnly(arr,
+                                           relativePositions,
+                                           rmfile,
+                                           log)
+        arr, r, relativePositions = A
         if 'remove_gaponly' in markupdict:
             markupdict['remove_gaponly'].update(r)
         else:
@@ -375,7 +442,8 @@ def main():
         log.info("Cropping ends")
         if not args.silent:
             print("Cropping ends")
-        arr, r = parsingFunctions.cropEnds(arr, nams, relativePositions, rmfile,
+        arr, r = parsingFunctions.cropEnds(arr, nams, relativePositions,
+                                           rmfile,
                                            log, args.crop_ends_mingap_perc,
                                            args.crop_ends_redefine_perc)
 
@@ -388,10 +456,11 @@ def main():
         if not args.silent:
             print("Removing gap only columns")
 
-        arr, r, relativePositions = parsingFunctions.removeGapOnly(arr,
-                                                                   relativePositions,
-                                                                   rmfile,
-                                                                   log)
+        A = parsingFunctions.removeGapOnly(arr,
+                                           relativePositions,
+                                           rmfile,
+                                           log)
+        arr, r, relativePositions = A
         if 'remove_gaponly' in markupdict:
             markupdict['remove_gaponly'].update(r)
         else:
@@ -406,7 +475,6 @@ def main():
         arr, r = parsingFunctions.removeTooShort(arr, nams, rmfile, log,
                                                  args.remove_min_length)
 
-
         markupdict['remove_short'] = r
         removed_seqs = removed_seqs | r
         nams = utilityFunctions.updateNams(nams, r)
@@ -417,17 +485,17 @@ def main():
         if not args.silent:
             print("Removing gap only columns")
 
-        arr, r, relativePositions = parsingFunctions.removeGapOnly(arr,
-                                                                   relativePositions,
-                                                                   rmfile,
-                                                                   log)
+        A = parsingFunctions.removeGapOnly(arr,
+                                           relativePositions,
+                                           rmfile,
+                                           log)
+        arr, r, relativePositions = A
         if 'remove_gaponly' in markupdict:
             markupdict['remove_gaponly'].update(r)
         else:
             markupdict['remove_gaponly'] = r
         removed_cols = removed_cols | r
         utilityFunctions.checkArrLength(arr, log)
-
 
     if args.remove_gaponly and not (args.all_options or
                                     args.remove_divergent or
@@ -438,38 +506,45 @@ def main():
         if not args.silent:
             print("Removing gap only columns")
 
-        arr, r, relativePositions = parsingFunctions.removeGapOnly(arr,
-                                                                   relativePositions,
-                                                                   rmfile,
-                                                                   log)
+        A = parsingFunctions.removeGapOnly(arr,
+                                           relativePositions,
+                                           rmfile,
+                                           log)
+        arr, r, relativePositions = A
         if 'remove_gaponly' in markupdict:
             markupdict['remove_gaponly'].update(r)
         else:
             markupdict['remove_gaponly'] = r
         removed_cols = removed_cols | r
         utilityFunctions.checkArrLength(arr, log)
-    
+
     if args.make_simmatrix_input or args.all_options:
         log.info("Building similarity matrix for input alignment")
         if not args.silent:
             print("Building similarity matrix for input alignment")
         outf = "%s_input_similarity.tsv" % (args.outfile_stem)
+        minoverlap = args.make_simmatrix_minoverlap
+        keepgaps = args.make_simmatrix_keepgaps
+        dp = args.make_simmatrix_dp
         similarityMatrix.calculateSimilarityMatrix(orig_arr,
                                                    orig_nams,
-                                                   minoverlap=args.make_simmatrix_minoverlap,
-                                                   keepgaps=args.make_simmatrix_keepgaps,
-                                                   outfile=outf, dp=args.make_simmatrix_dp)
+                                                   minoverlap=minoverlap,
+                                                   keepgaps=keepgaps,
+                                                   outfile=outf, dp=dp)
 
     if args.make_simmatrix_output or args.all_options:
         log.info("Building similarity matrix for output alignment")
         if not args.silent:
             print("Building similarity matrix for output alignment")
         outf = "%s_output_similarity.tsv" % (args.outfile_stem)
+        minoverlap = args.make_simmatrix_minoverlap
+        keepgaps = args.make_simmatrix_keepgaps
+        dp = args.make_simmatrix_dp
         similarityMatrix.calculateSimilarityMatrix(arr,
                                                    nams,
-                                                   minoverlap=args.make_simmatrix_minoverlap,
-                                                   keepgaps=args.make_simmatrix_keepgaps,
-                                                   outfile=outf, dp=args.make_simmatrix_dp)
+                                                   minoverlap=minoverlap,
+                                                   keepgaps=keepgaps,
+                                                   outfile=outf, dp=dp)
 
     if args.plot_input or args.all_options:
         log.info("Plotting mini alignment for input")
@@ -545,15 +620,18 @@ def main():
         consensusSeq.makeCoveragePlot(coverage, coverage_file)
 
     if args.make_sequence_logo or args.all_options:
+        figdpi = args.sequence_logo_dpi
+        figrowlength = args.sequence_logo_nt_per_row
         if args.sequence_logo_type == 'bar':
             log.info("Generating sequence logo bar chart")
             if not args.silent:
                 print("Generating sequence logo bar chart")
             out = "%s_logo_bar.%s" % (args.outfile_stem,
                                       args.sequence_logo_filetype)
+
             consensusSeq.sequence_bar_logo(arr, out, typ=typ,
-                                           figdpi=args.sequence_logo_dpi,
-                                           figrowlength=args.sequence_logo_nt_per_row)
+                                           figdpi=figdpi,
+                                           figrowlength=figrowlength)
         elif args.sequence_logo_type == 'text':
             log.info("Generating text sequence logo")
             if not args.silent:
@@ -561,9 +639,9 @@ def main():
             out = "%s_logo_text.%s" % (args.outfile_stem,
                                        args.sequence_logo_filetype)
             consensusSeq.sequence_logo(arr, out, typ=typ,
-                                       figdpi=args.sequence_logo_dpi,
+                                       figdpi=figdpi,
                                        figfontname=args.sequence_logo_font,
-                                       figrowlength=args.sequence_logo_nt_per_row)
+                                       figrowlength=figrowlength)
         elif args.sequence_logo_type == 'both':
             log.info("Generating sequence logo bar chart")
             if not args.silent:
@@ -571,22 +649,22 @@ def main():
             out = "%s_logo_bar.%s" % (args.outfile_stem,
                                       args.sequence_logo_filetype)
             consensusSeq.sequence_bar_logo(arr, out, typ=typ,
-                                           figdpi=args.sequence_logo_dpi,
-                                           figrowlength=args.sequence_logo_nt_per_row)
+                                           figdpi=figdpi,
+                                           figrowlength=figrowlength)
             log.info("Generating text sequence logo")
             if not args.silent:
                 print("Generating text sequence logo")
             out = "%s_logo_text.%s" % (args.outfile_stem,
                                        args.sequence_logo_filetype)
             consensusSeq.sequence_logo(arr, out, typ=typ,
-                                       figdpi=args.sequence_logo_dpi,
+                                       figdpi=figdpi,
                                        figfontname=args.sequence_logo_font,
-                                       figrowlength=args.sequence_logo_nt_per_row)
+                                       figrowlength=figrowlength)
 
     if args.unalign_input:
         log.info("Generating a gap free version of the input alignment")
         if not args.silent:
-            print ("Generating a gap free version of the input alignment")
+            print("Generating a gap free version of the input alignment")
         outf = "%s_unaligned_input.fasta" % (args.outfile_stem)
         unaligned_arr = utilityFunctions.unAlign(orig_arr)
         utilityFunctions.writeOutfile(outf, unaligned_arr,
@@ -595,7 +673,7 @@ def main():
     if args.replace_input:
         log.info("Generating a T instead of U version of the input alignment")
         if not args.silent:
-            print ("Generating a T instead of U version of the input alignment")
+            print("Generating a T instead of U version of the input alignment")
         outf = "%s_T_input.fasta" % (args.outfile_stem)
         T_arr = utilityFunctions.replaceUbyT(orig_arr)
         utilityFunctions.writeOutfile(outf, T_arr,
@@ -605,7 +683,8 @@ def main():
     if args.replace_output:
         log.info("Generating a T instead of U version of the output alignment")
         if not args.silent:
-            print ("Generating a T instead of U version of the output alignment")
+            print("Generating a T instead of U version of the output \
+alignment")
         outf = "%s_T_input.fasta" % (args.outfile_stem)
         T_arr = utilityFunctions.replaceUbyT(arr)
         utilityFunctions.writeOutfile(outf, T_arr,
@@ -615,16 +694,16 @@ def main():
     if args.unalign_output:
         log.info("Generating a gap free version of the output alignment")
         if not args.silent:
-            print ("Generating a gap free version of the output alignment")
+            print("Generating a gap free version of the output alignment")
         outf = "%s_unaligned_output.fasta" % (args.outfile_stem)
         unaligned_arr = utilityFunctions.unAlign(arr)
         utilityFunctions.writeOutfile(outf, unaligned_arr,
                                       nams,
                                       removed_seqs)
 
-
     utilityFunctions.writeOutfile(outfile, arr, orig_nams,
                                   removed_seqs, rmfile)
+
 
 if __name__ == "__main__":
     main()

--- a/CIAlign/CIAlign.py
+++ b/CIAlign/CIAlign.py
@@ -268,15 +268,12 @@ def main():
     cleaningArgs = [args.remove_insertions,
                     args.crop_ends,
                     args.remove_divergent]
+    # check numbers of sequences first
+
     if len(arr) < 3 and any(cleaningArgs):
         # when less than three sequences, stop
         print("You need at least three sequences in your MSA to run \
                remove_insertions, crop_ends or remove_divergent")
-        exit()
-    # check numbers of sequences first
-    if len(arr) < 3:
-        # when less than three sequences, stop
-        print("You need at least three sequences in your MSA.")
         exit()
 
     # store a copy of the original array

--- a/CIAlign/CIAlign.py
+++ b/CIAlign/CIAlign.py
@@ -265,7 +265,14 @@ def main():
     cmt_file = args.outfile_stem + "_cmt" # output file to store memory and time
     seqnumber = len(arr)
     msalength = len(arr[0])
-
+    cleaningArgs = [args.remove_insertions,
+                    args.crop_ends,
+                    args.remove_divergent]
+    if len(arr) < 3 and any(cleaningArgs):
+        # when less than three sequences, stop
+        print("You need at least three sequences in your MSA to run \
+               remove_insertions, crop_ends or remove_divergent")
+        exit()
     # check numbers of sequences first
     if len(arr) < 3:
         # when less than three sequences, stop

--- a/CIAlign/CIAlign.py
+++ b/CIAlign/CIAlign.py
@@ -319,7 +319,7 @@ def main():
         nams = utilityFunctions.updateNams(nams, r)
         utilityFunctions.checkArrLength(arr, log)
 
-    if args.remove_gaponly or args.all_options:
+    if (args.remove_divergent and args.remove_gaponly) or args.all_options:
         log.info("Removing gap only columns")
         if not args.silent:
             print("Removing gap only columns")
@@ -354,7 +354,7 @@ def main():
         utilityFunctions.checkArrLength(arr, log)
 
 
-    if args.remove_gaponly or args.all_options:
+    if (args.remove_insertions and args.remove_gaponly) or args.all_options:
         log.info("Removing gap only columns")
         if not args.silent:
             print("Removing gap only columns")
@@ -383,7 +383,7 @@ def main():
         removed_positions.update(r)
         utilityFunctions.checkArrLength(arr, log)
 
-    if args.remove_gaponly or args.all_options:
+    if (args.crop_ends and args.remove_gaponly) or args.all_options:
         log.info("Removing gap only columns")
         if not args.silent:
             print("Removing gap only columns")
@@ -412,7 +412,7 @@ def main():
         nams = utilityFunctions.updateNams(nams, r)
         utilityFunctions.checkArrLength(arr, log)
 
-    if args.remove_gaponly or args.all_options:
+    if (args.remove_short and args.remove_gaponly) or args.all_options:
         log.info("Removing gap only columns")
         if not args.silent:
             print("Removing gap only columns")
@@ -428,6 +428,27 @@ def main():
         removed_cols = removed_cols | r
         utilityFunctions.checkArrLength(arr, log)
 
+
+    if args.remove_gaponly and not (args.all_options or
+                                    args.remove_divergent or
+                                    args.remove_insertions or
+                                    args.crop_ends or
+                                    args.remove_short):
+        log.info("Removing gap only columns")
+        if not args.silent:
+            print("Removing gap only columns")
+
+        arr, r, relativePositions = parsingFunctions.removeGapOnly(arr,
+                                                                   relativePositions,
+                                                                   rmfile,
+                                                                   log)
+        if 'remove_gaponly' in markupdict:
+            markupdict['remove_gaponly'].update(r)
+        else:
+            markupdict['remove_gaponly'] = r
+        removed_cols = removed_cols | r
+        utilityFunctions.checkArrLength(arr, log)
+    
     if args.make_simmatrix_input or args.all_options:
         log.info("Building similarity matrix for input alignment")
         if not args.silent:

--- a/CIAlign/consensusSeq.py
+++ b/CIAlign/consensusSeq.py
@@ -1,16 +1,11 @@
 #! /usr/bin/env python
 
 import matplotlib
-matplotlib.use('Agg')
 from math import log
-import logging
-import argparse
 import numpy as np
-import scipy.interpolate as interpolate
+# import scipy.interpolate as interpolate
 import matplotlib.pyplot as plt
 import operator
-import os
-#from scipy.interpolate import spline #this one is obsolete
 import matplotlib.patheffects
 import math
 from matplotlib import gridspec
@@ -18,6 +13,8 @@ try:
     import CIAlign.utilityFunctions as utilityFunctions
 except ImportError:
     import utilityFunctions
+matplotlib.use('Agg')
+
 
 def getAxisUnits(subplot):
     '''
@@ -33,10 +30,14 @@ def getAxisUnits(subplot):
 
     Returns
     -------
-    D: Dictionary
-        keys are names of axis heights and widths, the values are in units or pixels
+    D: dict
+        Keys are names of axis heights and widths, the values are in units
+        or pixels
     '''
-    axis_dimensions = subplot.transData.transform([(subplot.get_xlim()[1], subplot.get_ylim()[1]),(0, 0)])- subplot.transData.transform((0,0))
+    axis_dimensions = subplot.transData.transform(
+        [(subplot.get_xlim()[1],
+          subplot.get_ylim()[1]), (0, 0)]) - subplot.transData.transform((
+              0, 0))
     D = dict()
     # height of y in pixels
     D['axis_height_px'] = axis_dimensions[0][1]
@@ -51,7 +52,7 @@ def getAxisUnits(subplot):
     # height of one y axis unit in pixels
     D['u_height_px'] = D['axis_height_px'] / D['axis_height_u']
     # width of one x axis unit in pixels
-    D['u_width_px'] =  D['axis_width_px'] / D['axis_width_u']
+    D['u_width_px'] = D['axis_width_px'] / D['axis_width_u']
 
     return (D)
 
@@ -143,11 +144,12 @@ def getLetters(typ='nt', fontname='monospace', dpi=500):
         a.set_ylim(0, 1)
         fs = getFontSize(f, a, 1)
         a.text(0.5, 0, base, fontsize=fs, fontdict={'family': 'monospace',
-                                                  'name': fontname},
+                                                    'name': fontname},
                color=colours[base], va='baseline', ha='center')
         plt.gca().set_axis_off()
         a.margins(0, 0)
-        f.subplots_adjust(top = 1, bottom = 0, right = 1, left = 0, wspace=None, hspace=None)
+        f.subplots_adjust(top=1, bottom=0, right=1, left=0,
+                          wspace=None, hspace=None)
         a.set_frame_on(False)
         # temporarily safe plot in working directory
         f.savefig("%s_temp.png" % base, dpi=500,
@@ -182,17 +184,17 @@ def findConsensus(alignment, log, consensus_type="majority"):
 
     consensus = []
     coverage = []
-    numberOfSequences = len(alignment[:,0])
+    numberOfSequences = len(alignment[:, 0])
 
     # need the reverse of array to access every column
-    for i in range(0,len(alignment[0,:])):
-        unique, counts = np.unique(alignment[:,i], return_counts=True)
+    for i in range(0, len(alignment[0, :])):
+        unique, counts = np.unique(alignment[:, i], return_counts=True)
         count = dict(zip(unique, counts))
         unique_ng = unique[unique != "-"]
         counts_ng = counts[unique != "-"]
         # deal with gap only columns
         if counts_ng.size == 0:
-            count_ng = {"N": len(alignment[:,i])}
+            count_ng = {"N": len(alignment[:, i])}
             nonGapContent = 0
         else:
             count_ng = dict(zip(unique_ng, counts_ng))
@@ -203,7 +205,8 @@ def findConsensus(alignment, log, consensus_type="majority"):
 
         # dealing with gap only collumns
         maxChar, maxCount = max(count.items(), key=operator.itemgetter(1))
-        maxChar_ng, maxCount_ng = max(count_ng.items(), key=operator.itemgetter(1))
+        maxChar_ng, maxCount_ng = max(count_ng.items(),
+                                      key=operator.itemgetter(1))
 
         # if there is an equal number of gap and non-gap characters at the
         # site, keep the non-gap character
@@ -226,7 +229,7 @@ def makeCoveragePlot(coverage, dest, dpi=300, height=3, width=5,
     coverage: list of strings
         Coverage for alignment
 
-    dest: string
+    dest: str
         folder to store file
 
     dpi: int
@@ -238,7 +241,7 @@ def makeCoveragePlot(coverage, dest, dpi=300, height=3, width=5,
     width: int
             height of plot, default: 5
 
-    colour: string
+    colour: str
             coverage colour (default: #007bf5)
 
     Returns
@@ -247,12 +250,14 @@ def makeCoveragePlot(coverage, dest, dpi=300, height=3, width=5,
     '''
 
     fontsize = 1500 / dpi
-    x = np.arange(0, len(coverage), 1);
+    x = np.arange(0, len(coverage), 1)
     y = coverage
-    xmin, xmax = x.min(), x.max()
-    N = 100
 
-    xx = np.linspace(xmin, xmax, N)
+    xmax = x.max()
+    # used for polynomial interpolation
+    # xmin = x.min()
+    # N = 100
+    # xx = np.linspace(xmin, xmax, N)
 
     # plain plotting of the coverage
     f = plt.figure(figsize=(width, height), dpi=dpi)
@@ -264,14 +269,16 @@ def makeCoveragePlot(coverage, dest, dpi=300, height=3, width=5,
     a.set_xticklabels([0, xmax], fontsize=fontsize)
     a.set_yticks(np.arange(0, 1.1, 0.5))
     a.set_yticklabels(np.arange(0, 1.1, 0.5), fontsize=fontsize)
-    #b = f.add_subplot('212')
+
+    # b = f.add_subplot('212')
 
     # polynomial interpolation leaving this in just in case
-    #c = f.add_subplot('313')
-    #z = np.polyfit(x, bla, 30)
-    #p = np.poly1d(z)
-    #c.plot(xx, p(xx))
-    #xnew = np.linspace(x.min(),x.max(),300) #300 represents number of points to make between T.min and T.max
+    # c = f.add_subplot('313')
+    # z = np.polyfit(x, bla, 30)
+    # p = np.poly1d(z)
+    # c.plot(xx, p(xx))
+    # xnew = np.linspace(x.min(),x.max(),300)
+    # 300 represents number of points to make between T.min and T.max
 
     # interpolating the coverage function to make it smooth
     # t, c, k = interpolate.splrep(x, y, s=0, k=4)
@@ -302,7 +309,7 @@ def sequence_logo(alignment,
     alignment: np.array
         The alignment stored as a numpy array
 
-    figname: string
+    figname: str
         name of figure
 
     typ: str
@@ -321,7 +328,7 @@ def sequence_logo(alignment,
     -------
     none
     '''
-    alignment_width = len(alignment[0,:])
+    alignment_width = len(alignment[0, :])
     if alignment_width < figrowlength:
         figrowlength = alignment_width
     nsegs = math.ceil(alignment_width / figrowlength)
@@ -342,17 +349,18 @@ def sequence_logo(alignment,
         # for each column calculate heights via entropy
         # and scale letters accordlingly
         for i in range(rstart, rend):
-            unique, counts = np.unique(alignment[:,i],
+            unique, counts = np.unique(alignment[:, i],
                                        return_counts=True)
             count = dict(zip(unique, counts))
             height_per_base, info_per_base = calc_entropy(count,
-                                                          len(alignment[:,0]),
+                                                          len(alignment[:, 0]),
                                                           typ=typ)
             height_sum_higher = 0
             for base, height in height_per_base.items():
                 if height > 0:
                     L = plt.imread("%s_temp.png" % base)
-                    a.imshow(L, extent=(i, i+1, height_sum_higher, height_sum_higher+height),
+                    a.imshow(L, extent=(i, i+1, height_sum_higher,
+                                        height_sum_higher+height),
                              filternorm=False)
                     height_sum_higher += height
         a.axis(limits)
@@ -367,11 +375,11 @@ def sequence_logo(alignment,
         rstart += figrowlength
         rend += figrowlength
     # obtain colours
-    if typ == 'nt':
-        allbases = utilityFunctions.getNtColours()
-    elif typ == 'aa':
-        allbases = utilityFunctions.getAAColours()
-    #for base in allbases:
+    #  if typ == 'nt':
+    #    allbases = utilityFunctions.getNtColours()
+    # elif typ == 'aa':
+    #    allbases = utilityFunctions.getAAColours()
+    # for base in allbases:
     #    os.unlink("%s_temp.png" % base)
     # save plot using figname
     f.savefig(figname, dpi=figdpi, bbox_inches='tight')
@@ -383,7 +391,6 @@ def sequence_bar_logo(alignment,
                       typ='nt',
                       figdpi=300,
                       figrowlength=50):
-
     '''
     Creates a sequence logo based on an entropy calculation using bars
     Scales the bars according to the information content of the alignment
@@ -394,7 +401,7 @@ def sequence_bar_logo(alignment,
     alignment: np.array
         The alignment stored as a numpy array
 
-    figname: string
+    figname: str
         name of figure
 
     typ: str
@@ -413,7 +420,7 @@ def sequence_bar_logo(alignment,
     -------
     none
     '''
-    alignment_width = len(alignment[0,:])
+    alignment_width = len(alignment[0, :])
     if alignment_width < figrowlength:
         figrowlength = alignment_width
     nsegs = math.ceil(alignment_width / figrowlength)
@@ -422,14 +429,13 @@ def sequence_bar_logo(alignment,
     rstart = 0
     rend = rstart + figrowlength
 
-
     for n in range(nsegs):
         if rend > alignment_width:
             rend = alignment_width
         axes = f.add_subplot(gs[n])
         axes.set_xlim(rstart-0.5, rend-0.5)
         axes.set_ylim(0, 2.1)
-        seq_count = len(alignment[:,0])
+        seq_count = len(alignment[:, 0])
         width = 0.75
         ind = np.arange(rstart, rend)
 
@@ -448,9 +454,10 @@ def sequence_bar_logo(alignment,
         # for each column calculate heights via entropy
         # and scale letters accordlingly
         for i in range(rstart, rend):
-            unique, counts = np.unique(alignment[:,i], return_counts=True)
+            unique, counts = np.unique(alignment[:, i], return_counts=True)
             count = dict(zip(unique, counts))
-            height_per_base, info_per_base = calc_entropy(count, seq_count, typ)
+            height_per_base, info_per_base = calc_entropy(count, seq_count,
+                                                          typ)
             bottom_height.append(0)
 
             # need a list of each nt/aa separately to plot them as bars
@@ -459,9 +466,9 @@ def sequence_bar_logo(alignment,
 
         # stag bars on top of each other
         for base, height in height_list.items():
-                plt.bar(ind, height, width, bottom=bottom_height, color=colours[base])
-                bottom_height = [i+j for i,j in zip(bottom_height,height)]
-
+            plt.bar(ind, height, width, bottom=bottom_height,
+                    color=colours[base])
+            bottom_height = [i+j for i, j in zip(bottom_height, height)]
 
         plt.xticks([rstart, rend-1], [rstart+1, rend])
         plt.yticks(np.arange(0, 2.1, 1))
@@ -485,7 +492,7 @@ def calc_entropy(count, seq_count, typ):
 
     Parameters
     ----------
-    count: dictonary
+    count: dict
         of nt/aa with counts
 
     seq_count: int
@@ -508,11 +515,11 @@ def calc_entropy(count, seq_count, typ):
     if typ == "nt":
         element_list = utilityFunctions.getNtColours()
         s = 4
-        max_entropy = log(4,2)
+        max_entropy = log(4, 2)
     elif typ == "aa":
         element_list = utilityFunctions.getAAColours()
         s = 20
-        max_entropy = log(20,2)
+        max_entropy = log(20, 2)
 
     info_per_base = {}
     freq_per_base = {}
@@ -544,7 +551,7 @@ def calc_entropy(count, seq_count, typ):
             freq_per_base[base] = frequency
             entropy -= frequency*log(frequency, 2)
             info_per_base[base] = max_entropy + frequency*log(frequency, 2)
-            entropy_per_base[base] = -frequency*log(frequency,2)
+            entropy_per_base[base] = -frequency * log(frequency, 2)
     information_per_column = max_entropy-entropy-sample_size_correction
 
     # if the information content is constant throughout the column,
@@ -554,7 +561,9 @@ def calc_entropy(count, seq_count, typ):
         if freq_per_base[base]*information_per_column < 0:
             height_per_base[base] = 0
         else:
-            #scale to accomodate gaps
-            height_per_base[base] = gap_correction*freq_per_base[base]*information_per_column
+            # scale to accomodate gaps
+            height_per_base[base] = (gap_correction *
+                                     freq_per_base[base] *
+                                     information_per_column)
 
     return height_per_base, info_per_base

--- a/CIAlign/cropSeq.py
+++ b/CIAlign/cropSeq.py
@@ -1,17 +1,19 @@
 #! /usr/bin/env python
 
+
 def determineStartEnd(sequence, mingap_perc=0.05, redefine_perc=0.1):
     '''
     Determines the start and the end of a sequence by calling a subroutine
 
     Parameters
     ----------
-    sequence: numpy array
+    sequence: np.array
         sequence
 
     mingap_perc: float
-        proportion of the sequence length (excluding gaps) that is the threshold
-        for change in gap numbers within the first 10% of non-gap positions of the sequence
+        proportion of the sequence length (excluding gaps) that is the
+        threshold for change in gap numbers within the first 10% of non-gap
+        positions of the sequence \
         (default: 0.05)
 
     redefine_perc: float
@@ -35,10 +37,10 @@ def determineStartEnd(sequence, mingap_perc=0.05, redefine_perc=0.1):
     # put in reverse for end
     end = len(sequence) - findValue(sequence[::-1], mingap_perc, redefine_perc)
 
-
     if start > end:
         return (0, 0)
     return(start, end)
+
 
 def findValue(sequence, mingap_perc=0.05, redefine_perc=0.1):
     '''
@@ -50,8 +52,9 @@ def findValue(sequence, mingap_perc=0.05, redefine_perc=0.1):
         sequence
 
     mingap_perc: float
-        proportion of the sequence length (excluding gaps) that is the threshold
-        for change in gap numbers within the first checkfor_perc% of non-gap positions of the sequence
+        proportion of the sequence length (excluding gaps) that is the
+        threshold for change in gap numbers within the first checkfor_perc %
+        of non-gap positions of the sequence
         (default: 0.05)
 
     redefine_perc: float
@@ -85,7 +88,8 @@ def findValue(sequence, mingap_perc=0.05, redefine_perc=0.1):
     if gaps[boundary1] < boundary3:
         return 0
 
-    # for more fluctuation within the sequence, meaning we observe a few nt within many gaps -> indicates incomplete sequence
+    # for more fluctuation within the sequence, meaning we observe a few nt
+    # within many gaps -> indicates incomplete sequence
     for n in range(0, boundary2):
         if gaps[n+1] - gaps[n] >= mingap:
             position = n + 1 + gaps[n+1]

--- a/CIAlign/miniAlignments.py
+++ b/CIAlign/miniAlignments.py
@@ -1,21 +1,20 @@
 #! /usr/bin/env python
 import numpy as np
 import matplotlib
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 try:
     import CIAlign.utilityFunctions as utilityFunctions
 except ImportError:
     import utilityFunctions
 import math
+matplotlib.use('Agg')
 
 
 def arrNumeric(arr, typ):
     '''
     Converts the sequence array into a numerical matrix and a colour map
     which matplotlib can interpret as an image (similar to
-    https://matplotlib.org/3.1.1/gallery/images_contours_and_fields/image_annotated_heatmap.html)
-
+                                                https://bit.ly/2CIKOEr)
     The rows in the array are inverted so that the output image has the rows
     in the same order as the input alignment.
 
@@ -62,7 +61,6 @@ def arrNumeric(arr, typ):
         for y in range(ali_height):
             # numeric version of the alignment array
             arr2[y, x] = nD[arr[y, x]]
-
 
     cmap = matplotlib.colors.ListedColormap(colours)
     return (arr2, cmap)
@@ -176,18 +174,18 @@ def drawMarkUpLegend(outfile):
     None
     '''
     legend = plt.figure(figsize=(2, 2), dpi=100)
-    l = legend.add_subplot(111)
+    leg = legend.add_subplot(111)
     colours = ['black', '#f434c5', "#7bc5ff", '#fff6b3', "#f57700"]
     functions = ['Cropped Ends', 'Too Divergent', 'Insertions',
                  'Too Short', 'Gap Only']
     for i, c in enumerate(colours):
-        l.plot(1, 5-i, marker='.', color=c, markersize=20)
-        l.text(2, 5-i, functions[i])
-    l.set_xlim(0.5, 3)
-    l.set_ylim(-1, 6)
-    l.set_axis_off()
+        leg.plot(1, 5-i, marker='.', color=c, markersize=20)
+        leg.text(2, 5-i, functions[i])
+    leg.set_xlim(0.5, 3)
+    leg.set_ylim(-1, 6)
+    leg.set_axis_off()
     legend.gca().set_axis_off()
-    l.margins(0, 0)
+    leg.margins(0, 0)
     legend.savefig("%s_legend.png" % (outfile),
                    dpi=100, bbox_inches='tight')
 
@@ -225,8 +223,8 @@ def drawMiniAlignment(arr, nams, log, outfile, typ,
         dictionary where the keys are function names and the values are
         lists of columns, rows or positions which have been removed
     ret: bool
-        return the subplot as a matplotlib object, used to make plots when using this function directly
-        rather than the CIAlign workflow
+        return the subplot as a matplotlib object, used to make plots when
+        using this function directly rather than the CIAlign workflow
 
     Returns
     -------

--- a/CIAlign/parsingFunctions.py
+++ b/CIAlign/parsingFunctions.py
@@ -133,7 +133,6 @@ def removeDivergent(arr, nams, rmfile, log, percidentity=0.75):
     r = set(np.array(nams)[np.invert(keep)])
     log.info("Removing divergent sequences %s" % (", ".join(list(r))))
 
-
     return (newarr, r)
 
 
@@ -191,7 +190,8 @@ def removeInsertions(arr, relativePositions, rmfile, log,
             # and less than mincov total coverage
             x = set(ns[(these_sums < left) &
                        (these_sums < right)])
-            put_indels = put_indels | x
+            if len(x) >= min_size:
+                put_indels = put_indels | x
     put_indels = np.array(sorted(list(put_indels)))
     # for the putative indels, check if there are more sequences
     # with a gap at this position (but with sequence on either side)
@@ -212,6 +212,7 @@ def removeInsertions(arr, relativePositions, rmfile, log,
                 leftsum >= min_flank) & (rightsum >= min_flank)))
         if lacks_region > covers_region:
             absolutePositions.add(p)
+            print (absolutePositions)
     # make a list of positions to remove
     rm_relative = set()
     for n in absolutePositions:

--- a/CIAlign/parsingFunctions.py
+++ b/CIAlign/parsingFunctions.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-
 import numpy as np
 import matplotlib
-matplotlib.use('Agg')
 try:
     import CIAlign.cropSeq as cropSeq
 except ImportError:
     import cropSeq
+matplotlib.use('Agg')
+
 
 def cropEnds(arr, nams, relativePositions, rmfile, log, mingap, redefine_perc):
     '''
@@ -65,12 +65,13 @@ def cropEnds(arr, nams, relativePositions, rmfile, log, mingap, redefine_perc):
                 out.write('\n')
             # list of positions between 0 and start which are not gaps
             startpos = np.where(row[0:start] != "-")[0]
-            # list of positions from end to end of the sequences which are not gaps
+            # list of positions from end to end of the sequences
+            # which are not gaps
             endpos = np.where(row[end:] != "-")[0] + end
             rel_startpos = np.array(relativePositions)[startpos]
             rel_endpos = np.array(relativePositions)[endpos]
             r[nam] = ((rel_startpos, rel_endpos))
-            #r[nam] = ((startpos, endpos))
+            # r[nam] = ((startpos, endpos))
         newarr.append(list(newseq))
     out.close()
     return (np.array(newarr), r)
@@ -218,8 +219,8 @@ def removeInsertions(arr, relativePositions, rmfile, log,
         rm_relative.add(relativePositions[n])
     for n in rm_relative:
         relativePositions.remove(n)
-    #for n in absolutePositions:
-    #    relativePositions.remove(n)
+    # for n in absolutePositions:
+    #     relativePositions.remove(n)
     rmpos = np.array(list(absolutePositions))
 
     keeppos = np.arange(0, len(sums))
@@ -230,7 +231,7 @@ def removeInsertions(arr, relativePositions, rmfile, log,
         out.write('\n')
     out.close()
     arr = arr[:, keeppos]
-    #return (arr, set(rmpos), relativePositions)
+    # return (arr, set(rmpos), relativePositions)
     return (arr, set(rm_relative), relativePositions)
 
 

--- a/CIAlign/parsingFunctions.py
+++ b/CIAlign/parsingFunctions.py
@@ -131,8 +131,8 @@ def removeDivergent(arr, nams, rmfile, log, percidentity=0.75):
     keep = np.array(keep)
     newarr = arr[keep, :]
     r = set(np.array(nams)[np.invert(keep)])
-    log.info("Removing divergent sequences %s" % (", ".join(list(r))))
-
+    if len(r) != 0:
+        log.info("Removing divergent sequences %s" % (", ".join(list(r))))
     return (newarr, r)
 
 
@@ -212,7 +212,6 @@ def removeInsertions(arr, relativePositions, rmfile, log,
                 leftsum >= min_flank) & (rightsum >= min_flank)))
         if lacks_region > covers_region:
             absolutePositions.add(p)
-            print (absolutePositions)
     # make a list of positions to remove
     rm_relative = set()
     for n in absolutePositions:
@@ -225,9 +224,10 @@ def removeInsertions(arr, relativePositions, rmfile, log,
 
     keeppos = np.arange(0, len(sums))
     keeppos = np.invert(np.in1d(keeppos, rmpos))
-    log.info("Removing sites %s" % (", ".join([str(x) for x in rmpos])))
-    out.write("Removing sites %s" % (", ".join([str(x) for x in rmpos])))
-    out.write('\n')
+    if len(rmpos) != 0:
+        log.info("Removing sites %s" % (", ".join([str(x) for x in rmpos])))
+        out.write("Removing sites %s" % (", ".join([str(x) for x in rmpos])))
+        out.write('\n')
     out.close()
     arr = arr[:, keeppos]
     #return (arr, set(rmpos), relativePositions)
@@ -265,7 +265,8 @@ def removeTooShort(arr, nams, rmfile, log, min_length):
         sums = sum(arrT != "-")
         arr = arr[sums > min_length]
         rmnames = set(np.array(nams)[sums <= min_length])
-        log.info("Removing sequences %s" % (", ".join(list(rmnames))))
+        if len(rmnames) != 0:
+            log.info("Removing sequences %s" % (", ".join(list(rmnames))))
     else:
         rmnames = set()
 
@@ -313,15 +314,15 @@ def removeGapOnly(arr, relativePositions, rmfile, log):
             relativePositions.remove(n)
         rmpos = set(rmpos)
         arr = arr[:, sums != len(arr[:, 0])]
-        log.info("Removing gap only sites %s" % (
-                ", ".join([str(x) for x in rmpos])))
-        out.write("Removing gap only sites %s" % (
-                ", ".join([str(x) for x in rmpos])))
-        out.write('\n')
+        if len(rmpos) != 0:
+            log.info("Removing gap only sites %s" % (
+                    ", ".join([str(x) for x in rmpos])))
+            out.write("Removing gap only sites %s" % (
+                    ", ".join([str(x) for x in rmpos])))
+            out.write('\n')
 
     else:
         rmpos = set()
-
 
     out.close()
     return (arr, rmpos, relativePositions)

--- a/CIAlign/similarityMatrix.py
+++ b/CIAlign/similarityMatrix.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import numpy as np
 import matplotlib
-matplotlib.use('Agg')
 import itertools
+matplotlib.use('Agg')
+
 
 def calculateSimilarityMatrix(arr, nams, minoverlap=1,
                               keepgaps=False, outfile=None, dp=4):

--- a/CIAlign/utilityFunctions.py
+++ b/CIAlign/utilityFunctions.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-
 import numpy as np
 import matplotlib
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+matplotlib.use('Agg')
 
 
 def replaceUbyT(arr):
@@ -24,6 +23,7 @@ def replaceUbyT(arr):
     arr = np.where(arr == "U", "T", arr)
     return (arr)
 
+
 def unAlign(arr):
     '''
     Removes all gaps from the alignment.
@@ -41,6 +41,7 @@ def unAlign(arr):
 
     arr = np.where(arr == "-", "", arr)
     return (arr)
+
 
 def FastaToArray(infile, outfile_stem):
     '''
@@ -70,10 +71,10 @@ def FastaToArray(infile, outfile_stem):
         for line in input:
             line = line.strip()
             if line[0] == ">":
-                    seqs.append([s.upper() for s in seq])
-                    nams.append(nam)
-                    seq = []
-                    nam = line.replace(">", "")
+                seqs.append([s.upper() for s in seq])
+                nams.append(nam)
+                seq = []
+                nam = line.replace(">", "")
             else:
                 seq += list(line)
     seqs.append([s.upper() for s in seq])
@@ -155,7 +156,7 @@ def getNtColours():
             "D": '#b2b2b2',
             "H": '#b2b2b2',
             "V": '#b2b2b2',
-            "X": '#b2b2b2',}
+            "X": '#b2b2b2'}
 
 
 def writeOutfile(outfile, arr, nams, removed, rmfile=None):
@@ -279,8 +280,10 @@ def checkArrLength(arr, log):
     -------
     None
     '''
-    emptyAlignmentMessage = """Error: Parsing your alignment with these settings has removed all of the sequences."""
-    differentLengthsMessage = """Error: The sequences in your alignment are not all the same length."""
+    emptyAlignmentMessage = """Error: Parsing your alignment with these \
+settings has removed all of the sequences."""
+    differentLengthsMessage = """Error: The sequences in your alignment are \
+not all the same length."""
     if 0 in np.shape(arr):
         log.error(emptyAlignmentMessage)
         print(emptyAlignmentMessage)
@@ -313,11 +316,17 @@ def listFonts(outfile):
     for fname in flist:
         try:
             F = matplotlib.font_manager.FontProperties(fname=fname)
-            g = F.get_name()
-            flist2.add(g)
-        except:
+            font = matplotlib.font_manager.get_font(fname)
+            L = font.get_charmap()
+            # this tests if matplotlib can actually render "ACTG" in this
+            # font
+            if 108 in L:
+                g = F.get_name()
+                flist2.add(g)
+        except RuntimeError:
             # Some of the fonts seem not to have a name? Ignore these.
             pass
+
     flist2 = sorted(list(flist2))[::-1]
     f = plt.figure(figsize=(5, len(flist2) / 4), dpi=200)
     a = f.add_subplot(111)
@@ -327,6 +336,7 @@ def listFonts(outfile):
     for i, fname in enumerate(flist2):
         a.text(0.7, i, "ACTG", fontdict={'name': fname, 'size': 14})
         a.text(0, i, fname, fontsize=10)
+
     a.text(0.7, i+1, "Sample", fontsize=10, fontweight='bold')
     a.text(0, i+1, "Font Name", fontsize=10, fontweight='bold')
     a.set_axis_off()


### PR DESCRIPTION
I have:

- Fixed a bug in remove_insertions - it was sometimes removing insertions smaller than the minimum size the user sets - I've fixed it now

- Made it so that you need a minimum of three sequences for remove_insertions, crop_ends and remove_divergent but a minimum of two for everything else - I think it's ok to remove gap only or short (or make mini alignments or a consensus) with two sequences.

- Made it only run remove gap only multiple times if you actually run multiple cleaning functions - before it ran four times always

- It was logging "removed sites: " with no numbers if it removed none - now it just logs nothing

- Made everything consistent with the pep8 python style guide -  https://www.python.org/dev/peps/pep-0008/ - the vast majority of the changes are for this and are either splitting lines so they are not too long and removing or adding whitespace.