### PR TITLE
added option to keep sequence names in mini alignments

### DIFF
--- a/CIAlign/argP.py
+++ b/CIAlign/argP.py
@@ -549,7 +549,13 @@ def getParser():
                        is switched on) the rows will be labelled \
                        based on the input alignment, rather \
                        than renumbered. Default: %(default)s")
-
+    optional.add("--plot_keep_names", dest="plot_keep_names",
+                 action="store_true",
+                 help="If specified, rows in mini alignments will \
+                 be named as in the original file, \
+                 rather than numbered. Note that in many cases \
+                 this is impractical in terms of making the image \
+                 a reasonable height. Default: %(default)s")
     optional.add("--plot_force_numbers", dest="plot_force_numbers",
                  action="store_true",
                  help="Force all rows to be numbered on the mini alignments \

--- a/CIAlign/miniAlignments.py
+++ b/CIAlign/miniAlignments.py
@@ -250,7 +250,8 @@ def drawMarkUpLegend(outfile, palette="CBS"):
 def drawMiniAlignment(arr, nams, log, outfile, typ, plot_type='standard',
                       dpi=300, title=None, width=5, height=3, markup=False,
                       markupdict=None, ret=False, orig_nams=[],
-                      keep_numbers=False, force_numbers=False, palette="CBS",
+                      keep_numbers=False, keep_nams=False,
+                      force_numbers=False, palette="CBS",
                       plot_identity_palette='bone',
                       plot_identity_gap_col='white',
                       plot_similarity_palette='bone',
@@ -310,6 +311,8 @@ def drawMiniAlignment(arr, nams, log, outfile, typ, plot_type='standard',
     keep_numbers: bool
         Number the sequences (rows) based on the original CIAlign input rather
         than renumbering.
+    keep_names: bool
+        Show sequence names rather than numbers.   
     palette: str
         Colour palette, CBS or Bright
     plot_identity_palette: str
@@ -396,22 +399,30 @@ def drawMiniAlignment(arr, nams, log, outfile, typ, plot_type='standard',
         f.suptitle(title, fontsize=fontsize*1.5, y=0.92)
     for t in a.get_xticklabels():
         t.set_fontsize(fontsize)
-    a.set_yticks(np.arange(ali_height-1, -1, -tickint))
-    x = 1
-    if tickint == 1:
-        if keep_numbers:
-            labs = []
-            for nam in orig_nams:
-                if nam in nams:
-                    labs.append(x)
-                x += 1
-            a.set_yticklabels(labs,
-                              fontsize=fontsize*0.75)
-        else:
-            a.set_yticklabels(np.arange(1, ali_height+1, tickint),
-                              fontsize=fontsize*0.75)
+    
+    if keep_nams:
+        a.set_yticks(np.arange(ali_height-1, -1, -1))
+        a.set_yticklabels(nams, fontsize=fontsize)
     else:
-        a.set_yticklabels(np.arange(0, ali_height, tickint), fontsize=fontsize)
+        a.set_yticks(np.arange(ali_height-1, -1, -tickint))
+        x = 1
+        if tickint == 1:
+            if keep_numbers:
+                labs = []
+                for nam in orig_nams:
+                    if nam in nams:
+                        labs.append(x)
+                    x += 1
+                a.set_yticklabels(labs,
+                                  fontsize=fontsize*0.75)
+            elif not keep_nams:
+                a.set_yticklabels(np.arange(1, ali_height+1, tickint),
+                                  fontsize=fontsize*0.75)
+    
+        else:
+            if not keep_nams:
+                a.set_yticklabels(np.arange(0, ali_height, tickint),
+                                  fontsize=fontsize)
 
     if markup:
         a = drawMarkUp(a, markupdict, nams, ali_width, ali_height, palette)

--- a/CIAlign/runCIAlign.py
+++ b/CIAlign/runCIAlign.py
@@ -829,6 +829,8 @@ def runMiniAlignments(args, log, orig_arr, orig_nams, arr, nams,
         Either 'aa' - amino acid - or 'nt' - nucleotide
     '''
     fn = args.plot_force_numbers
+    kn = args.plot_keep_numbers
+
     # Mini alignment of CIAlign input
     if args.plot_input or args.all_options or args.visualise:
         log.info("Plotting mini alignment for input")
@@ -839,6 +841,8 @@ def runMiniAlignments(args, log, orig_arr, orig_nams, arr, nams,
                                          outf, typ,
                                          dpi=args.plot_dpi,
                                          title=False,
+                                         keep_numbers=kn,
+                                         keep_nams=args.plot_keep_names,
                                          width=args.plot_width,
                                          height=args.plot_height,
                                          force_numbers=fn,
@@ -850,26 +854,17 @@ def runMiniAlignments(args, log, orig_arr, orig_nams, arr, nams,
         if not args.silent:
             print("Plotting mini alignment for output")
         outf = "%s_output.%s" % (args.outfile_stem, args.plot_format)
-        if not args.plot_keep_numbers:
-            miniAlignments.drawMiniAlignment(arr, nams, log,
-                                             outf, typ,
-                                             dpi=args.plot_dpi,
-                                             title=False,
-                                             width=args.plot_width,
-                                             height=args.plot_height,
-                                             force_numbers=fn,
-                                             palette=args.palette)
-        else:
-            miniAlignments.drawMiniAlignment(arr, nams, log,
-                                             outf, typ,
-                                             dpi=args.plot_dpi,
-                                             title=False,
-                                             width=args.plot_width,
-                                             height=args.plot_height,
-                                             orig_nams=orig_nams,
-                                             keep_numbers=True,
-                                             force_numbers=fn,
-                                             palette=args.palette)
+        miniAlignments.drawMiniAlignment(arr, nams, log,
+                                         outf, typ,
+                                         dpi=args.plot_dpi,
+                                         title=False,
+                                         keep_numbers=kn,
+                                         keep_nams=args.plot_keep_names,
+                                         width=args.plot_width,
+                                         height=args.plot_height,
+                                         force_numbers=fn,
+                                         palette=args.palette)
+
     # Markup plot
     # todo: what if only interpret functions are called?
     if args.plot_markup or args.all_options or args.visualise:
@@ -881,6 +876,8 @@ def runMiniAlignments(args, log, orig_arr, orig_nams, arr, nams,
                                          outf, typ,
                                          dpi=args.plot_dpi,
                                          title=False,
+                                         keep_numbers=kn,
+                                         keep_nams=args.plot_keep_names,
                                          width=args.plot_width,
                                          height=args.plot_height,
                                          markup=True,
@@ -899,6 +896,8 @@ def runMiniAlignments(args, log, orig_arr, orig_nams, arr, nams,
             plot_type='identity',
             dpi=args.plot_dpi,
             title=False,
+            keep_numbers=kn,
+            keep_nams=args.plot_keep_names,
             width=args.plot_width,
             height=args.plot_height,
             force_numbers=fn,
@@ -918,6 +917,8 @@ def runMiniAlignments(args, log, orig_arr, orig_nams, arr, nams,
             plot_type='similarity',
             dpi=args.plot_dpi,
             title=False,
+            keep_numbers=kn,
+            keep_nams=args.plot_keep_names,
             width=args.plot_width,
             height=args.plot_height,
             force_numbers=fn,

--- a/man/pages/usage.md
+++ b/man/pages/usage.md
@@ -237,6 +237,7 @@ Output files:
 | *`--plot_width`* | Mini alignment width in inches | 5 |
 | *`--plot_height`* | Mini alignment height in inches | 3 |
 | *`--plot_keep_numbers`* | Label rows in mini alignments based on input alignment, rather than renumbering | False |
+| *`--plot_keep_names`* | Label rows in mini alignments with names from the original alignment, rather than numbers. This can be impractical for large alignments as the labels will overlap | False |
 | *`--plot_force_numbers`* | Force all rows in mini alignments to be numbered rather than labelling e.g. every 10th row for larger plots Will cause labels to overlap in larger plots | False |
 | *`--plot_sub_matrix_name`* | Substitution matrix to use for similarity plots |  BLOSUM62 for amino acid, NUC.4.4 for nucleotide  |
 | *`--plot_identity_palette`* | Matplotlib palette name for identity mini alignments. | bone |


### PR DESCRIPTION
Hi Lotti @schnamo, I added an option to keep the sequence names in mini alignments (rather than swapping them for numbers) in response to https://github.com/KatyBrown/CIAlign/issues/67. I added to the manual but didn't yet make a test, but it's a pretty minor change and doesn't change the default behaviour.  <3