### PR TITLE
Fix AttributeError in drawMarkUp by converting nams to a list

### DIFF
--- a/CIAlign/miniAlignments.py
+++ b/CIAlign/miniAlignments.py
@@ -124,6 +124,8 @@ def drawMarkUp(a, markupdict, nams, ali_width, ali_height,
     if "crop_ends" in markupdict:
         colour = colD['crop_ends']
         for nam, boundary in markupdict['crop_ends'].items():
+            if isinstance(nams, np.ndarray):
+                nams = nams.tolist()
             y = len(nams) - nams.index(nam) - 1
             # left end of the sequence
             if boundary[0].shape[0] > 0:


### PR DESCRIPTION
Resolved an issue in miniAlignments.py where nams, a numpy.ndarray, caused an AttributeError due to the use of the index method, which is unavailable for numpy arrays. Added a type check to convert nams to a list before calling index. This ensures compatibility and prevents runtime errors when handling nams in drawMarkUp.